### PR TITLE
Switch to project_plugins rather than plugins

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -27,7 +27,7 @@
     ]}
 ]}.
 
-{plugins, [
+{project_plugins, [
   {geas_rebar3, {git, "https://github.com/crownedgrouse/geas_rebar3.git", {branch, "master"}}},
   rebar3_hex
 ]}.


### PR DESCRIPTION
This was resulting in `rebar3_hex` and `geas_rebar3` being pulled-in as a dependency needlessly in downstream projects in some situations.

More on plugins vs project plugins: https://rebar3.readme.io/docs/using-available-plugins