### PR TITLE
Ensure that values of scalars `String` and `Int` have the correct type

### DIFF
--- a/src/graphql_scalar_binary_coerce.erl
+++ b/src/graphql_scalar_binary_coerce.erl
@@ -2,7 +2,8 @@
 
 -export([input/2, output/2]).
 
-input(_, X) -> {ok, X}.
+input(_, B) when is_binary(B) -> {ok, B};
+input(_, _) -> {error, not_string}.
 
 %% According to the specification, Jun2018, we should
 %% accept coercion as long as we are not "loosing information"

--- a/src/graphql_scalar_integer_coerce.erl
+++ b/src/graphql_scalar_integer_coerce.erl
@@ -14,7 +14,8 @@ input(Ty, X) when is_float(X) ->
     end;
 input(_, X) when is_integer(X), X > ?MAX_INT -> {error, not_int32_value};
 input(_, X) when is_integer(X), X < ?MIN_INT -> {error, not_int32_value};
-input(_, X) -> {ok, X}.
+input(_, X) when is_integer(X) -> {ok, X};
+input(_, _X)  -> {error, not_integer}.
 
 output(<<"Int">>, I) when is_integer(I) ->
     if


### PR DESCRIPTION
I figured out that the server accepts values for `Int` and `String` scalars that don't follow the type defined in the schema. 
This PR adds simple checks to `Int` and `String` scalars resolvers that ensure the type is correct.