### PR TITLE
Use `no_auto_import` to avoid ambiguity with existing BIF for `alias/1`

### DIFF
--- a/src/graphql_execute.erl
+++ b/src/graphql_execute.erl
@@ -7,6 +7,7 @@
 -compile(inline).
 -compile(inline_list_funcs).
 -compile({inline_size, 50}).
+-compile({no_auto_import, [alias/1]}).
 
 -export([x/1, x/2]).
 -export([builtin_input_coercer/1]).


### PR DESCRIPTION
It currently displays a warning
```
Warning: ambiguous call of overridden auto-imported BIF alias/1
 - use erlang:alias/1 or "-compile({no_auto_import,[alias/1]})." to resolve name clash
%  312|                            orddict:append(alias(S), S, Grouped));
```