### PR TITLE
Fix .dot file generator; add to tests

### DIFF
--- a/src/graphql_dot.erl
+++ b/src/graphql_dot.erl
@@ -150,7 +150,8 @@ id(#union_type { id = ID }) -> ID;
 id(#scalar_type { id = ID }) -> ID;
 id(#input_object_type { id = ID }) -> ID;
 id(#object_type { id = ID }) -> ID;
-id(#root_schema { id = ID }) -> ID.
+id(#root_schema { id = ID }) -> ID;
+id(#directive_type{ id = ID }) -> ID.
 
 %% ----------------------------
 join(_Sep, []) -> [];

--- a/test/dungeon_SUITE.erl
+++ b/test/dungeon_SUITE.erl
@@ -55,7 +55,8 @@ end_per_testcase(_Case, _Config) ->
 groups() ->
     Dungeon =
         {dungeon, [],
-         [ unions,
+         [ dump_dot,
+           unions,
            defer,
            union_errors,
            error_handling,
@@ -121,6 +122,9 @@ run(Config, Q, Params) ->
 run(Config, File, Q, Params) ->
     {ok, Doc} = read_doc(Config, File),
     th:x(Config, Doc, Q, Params).
+
+dump_dot(_Config) ->
+    ok = graphql_dot:dump("./dungeon_schema.dot").
 
 default_query(Config) ->
     ID = ?config(known_goblin_id_1, Config),

--- a/test/star_wars_SUITE.erl
+++ b/test/star_wars_SUITE.erl
@@ -6,7 +6,7 @@
          init_per_testcase/2, end_per_testcase/2]).
 
 -export([hero/1, friends/1, query_id_params/1, query_aliases/1,
-         fragments/1, typename/1]).
+         fragments/1, typename/1, dump_dot/1]).
 
 -export([complex/1, non_existent_field/1, fields_on_objects/1,
          no_fields_on_interfaces/1, no_fields_on_scalars/1,
@@ -46,7 +46,8 @@ groups() ->
               query_id_params,
               query_aliases,
               fragments,
-              typename
+              typename,
+              dump_dot
              ]},
 
     Validation = {validation, [shuffle, parallel],
@@ -234,6 +235,9 @@ typename(Config) ->
     }},
     Expected = th:x(Config, Q1),
     ok.
+
+dump_dot(_Config) ->
+    ok = graphql_dot:dump("./star_wars_schema.dot").
 
 %% -- STAR WARS™ VALIDATION ------------------------------
 


### PR DESCRIPTION
Just make sure that `dungeon` and `star_wars` schemas can be dumped.